### PR TITLE
Replace gitlab with github for flake8

### DIFF
--- a/_templates/.pre-commit-config.yaml
+++ b/_templates/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
   endrequires::mypy>>
 
   <<requires::flake8
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
       - id: flake8


### PR DESCRIPTION
I'm not sure if you want to eventually replace flake8 here, but here I replaced the broken gitlab reference in the meantime.